### PR TITLE
Removed code that adds duplicate list.Title(s) to TokenDefinition list.

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -83,23 +83,23 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
             }
 
-            if (web.IsSubSite())
-            {
-                // Add lists from rootweb
-                var rootWeb = (web.Context as ClientContext).Site.RootWeb;
-                rootWeb.EnsureProperty(w => w.ServerRelativeUrl);
-                rootWeb.Context.Load(rootWeb.Lists, ls => ls.Include(l => l.Id, l => l.Title, l => l.RootFolder.ServerRelativeUrl));
-                rootWeb.Context.ExecuteQueryRetry();
-                foreach (var rootList in rootWeb.Lists)
-                {
-                    // token already there? Skip the list
-                    if (web.Lists.FirstOrDefault(l => l.Title == rootList.Title) == null)
-                    {
-                        _tokens.Add(new ListIdToken(web, rootList.Title, rootList.Id));
-                        _tokens.Add(new ListUrlToken(web, rootList.Title, rootList.RootFolder.ServerRelativeUrl.Substring(rootWeb.ServerRelativeUrl.Length + 1)));
-                    }
-                }
-            }
+            //if (web.IsSubSite())
+            //{
+            //    // Add lists from rootweb
+            //    var rootWeb = (web.Context as ClientContext).Site.RootWeb;
+            //    rootWeb.EnsureProperty(w => w.ServerRelativeUrl);
+            //    rootWeb.Context.Load(rootWeb.Lists, ls => ls.Include(l => l.Id, l => l.Title, l => l.RootFolder.ServerRelativeUrl));
+            //    rootWeb.Context.ExecuteQueryRetry();
+            //    foreach (var rootList in rootWeb.Lists)
+            //    {
+            //        // token already there? Skip the list
+            //        if (web.Lists.FirstOrDefault(l => l.Title == rootList.Title) == null)
+            //        {
+            //            _tokens.Add(new ListIdToken(web, rootList.Title, rootList.Id));
+            //            _tokens.Add(new ListUrlToken(web, rootList.Title, rootList.RootFolder.ServerRelativeUrl.Substring(rootWeb.ServerRelativeUrl.Length + 1)));
+            //        }
+            //    }
+            //}
 
             // Add ContentTypes
             web.Context.Load(web.AvailableContentTypes, cs => cs.Include(ct => ct.StringId, ct => ct.Name));


### PR DESCRIPTION
This will allow lists with the same name (in the sitecollection.rootweb)  to be create in a subweb.

| Q               | A
| --------------- | ---
| Bug fix?        | no - yes?
| New feature?    | no - yes?
| New sample?      | no - yes?
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Please describe the changes in this PR. Sample description or details around bugs which are being fixed.


#### Guidance
*You can delete this section when you are submitting the pull request.* 
* *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
* *Please target your PR to Dev branch.*